### PR TITLE
v4.2.2: Fix "Undefined array key storeCardOnFile" PHP warning

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,11 @@
 
 Changelog
 
+2026-07-27 - version 4.2.2
+
+= Fixes = 
+	- Adding a null guard to prevent "Undefined array key storeCardOnFile" PHP warning when processing payments whose confirmation data omits the field
+
 2026-06-11 - version 4.2.1
 
 = Fixes =

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.2.1",
+    "version": "4.2.2",
     "name": "dna/woocommerce",
     "description": "DNA payments gateway for Woocommerce",
     "type": "wordpress-plugin",

--- a/includes/utils/class-order-helper.php
+++ b/includes/utils/class-order-helper.php
@@ -134,7 +134,7 @@ class OrderHelper {
 
             // Handle saving card tokens. Status "on-hold" means that add_token already processed
             $is_processed = $new_status !== $status && $status === 'on-hold';
-            $should_add_token = $this->gateway->enabled_saved_cards && ($input['storeCardOnFile'] || $custom_data['store_card_on_file']);
+            $should_add_token = $this->gateway->enabled_saved_cards && ( ! empty( $input['storeCardOnFile'] ) || $custom_data['store_card_on_file'] );
             if ( ! $is_processed && ($should_add_token || $custom_data['allowed_recurring']) ) {
                 $token_result = $this->gateway->paymentTokenHelper->add_token($input, $order->get_payment_method(), (bool) ($custom_data['allowed_recurring'] ?? false));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wc-dnapayments",
-    "version": "4.2.1",
+    "version": "4.2.2",
     "description": "A WooCommerce payment gateway for DNAPayments.",
     "scripts": {
         "build": "wp-scripts build",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: payment gateway, credit card, woocommerce, dna payments, apple pay, google
 Requires at least: 4.2
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 4.2.1
+Stable tag: 4.2.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 WC requires at least: 4.8
@@ -74,6 +74,11 @@ For support, please contact DNA Payments directly through their website at https
 3. Apple Pay and Google Pay buttons
 
 == Changelog ==
+
+= 4.2.2 - 2026-07-27 =
+
+= Fixes = 
+	- Adding a null guard to prevent "Undefined array key storeCardOnFile" PHP warning when processing payments whose confirmation data omits the field
 
 = 4.2.1 - 2026-06-11 =
 

--- a/woocommerce-gateway-dnapayments.php
+++ b/woocommerce-gateway-dnapayments.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce DNA Payments Gateway
  * Plugin URI: https://www.dnapayments.com
  * Description: Take credit card payments on your store.
- * Version: 4.2.1
+ * Version: 4.2.2
  *
  * Author: DNA Payments Integration
  * Author URI: https://www.dnapayments.com
@@ -44,7 +44,7 @@ class WC_DNA_Payments {
 	public static $name = 'DNA Payments';
 
 	// Plugin version
-	public static $version = '4.2.1';
+	public static $version = '4.2.2';
 
 	// Wordpress supported min version
 	public static $wp_min_version = '4.2';


### PR DESCRIPTION
Adds a null guard around `$input['storeCardOnFile']` in `OrderHelper::process_payment()` to stop a PHP 8 warning being logged on every payment whose confirmation data omits that field.
